### PR TITLE
fix(deploy.tsx): change default to public fee

### DIFF
--- a/src/pages/deploy.tsx
+++ b/src/pages/deploy.tsx
@@ -57,6 +57,7 @@ const Deploy: NextPageWithLayout = () => {
       WalletAdapterNetwork.Testnet,
       program,
       Math.floor(parseFloat(fee) * 1_000_000),
+      false,
     );
 
     const txId =


### PR DESCRIPTION
Fixing unable to deploy error.
It's because of default fees is set to private fees. Changing to default public fees.

<img width="1641" alt="Screenshot 2024-02-26 at 10 44 27 PM" src="https://github.com/demox-labs/art-factory/assets/53001910/a5a9364a-f6ac-485b-8d10-1fea558937f4">
The error ^
<br />
<br />
<img width="341" alt="Screenshot 2024-02-26 at 11 21 20 PM" src="https://github.com/demox-labs/art-factory/assets/53001910/66d06564-f08a-423c-be4a-08ced16b76ac">
<img width="838" alt="Screenshot 2024-02-26 at 11 15 05 PM" src="https://github.com/demox-labs/art-factory/assets/53001910/71126024-bc83-4105-a99e-1847efb5621a">
Problem ^